### PR TITLE
Allow multiple Chart files at once

### DIFF
--- a/chparse/chart.py
+++ b/chparse/chart.py
@@ -3,14 +3,6 @@ from .instrument import Instrument
 from . import flags
 
 class Chart:
-    """Represents an entire chart."""
-    instruments = {
-        flags.EXPERT: {},
-        flags.HARD: {},
-        flags.MEDIUM: {},
-        flags.EASY: {},
-        flags.NA: {}
-    }
 
     @property
     def events(self):
@@ -31,6 +23,14 @@ class Chart:
 
     def __init__(self, metadata):
         self.__dict__.update(metadata)
+        self.instruments = {
+            flags.EXPERT: {},
+            flags.HARD: {},
+            flags.MEDIUM: {},
+            flags.EASY: {},
+            flags.NA: {}
+        }
+
 
     @staticmethod
     def _check_type(obj, cls):


### PR DESCRIPTION
Currently, two calls to chparse.load(file) will return two separate Chart files backed by the same instruments dict resulting in a Chart object that may have incorrect values in the instruments.

Fix this by making instruments part of each instance instead of a class field.